### PR TITLE
Update supported Docker version of Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Swarm (mode), Compose, Kubernetes, and OpenShift are supported are supported in 
 
 Hub will be supported on the following orchestrations:
 
-* Docker 17.03
-* Docker 17.06
-* Docker 17.09
-* Docker 17.12
+* Docker 17.06.x
+* Docker 17.09.x
+* Docker 17.12.x
+* Docker 18.03.x
 * Kubernetes 1.6
 * Kubernetes 1.7
 * Kubernetes 1.8


### PR DESCRIPTION
Since Hub 4.6.0, Docker 17.03.x is not supported.
Based on the installation guide and release notes, I updated the supported Docker version.

https://github.com/blackducksoftware/hub/blob/release/4.6.0/docs/release_notes_bd_hub.pdf
at Page 11
https://github.com/blackducksoftware/hub/blob/release/4.6.1/docs/en_US/hub_install_compose.pdf
at Page 3