### PR TITLE
ability to self-manage db creds

### DIFF
--- a/kubernetes/blackduck/templates/postgres-config.yaml
+++ b/kubernetes/blackduck/templates/postgres-config.yaml
@@ -21,6 +21,7 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation
   name: {{ .Release.Name }}-blackduck-db-config
   namespace: {{ .Release.Namespace }}
+{{ if eq .Values.postgres.createSecret true}}
 ---
 apiVersion: v1
 data:
@@ -38,3 +39,4 @@ metadata:
   name: {{ .Release.Name }}-blackduck-db-creds
   namespace: {{ .Release.Namespace }}
 type: Opaque
+{{ end }}

--- a/kubernetes/blackduck/values.yaml
+++ b/kubernetes/blackduck/values.yaml
@@ -84,6 +84,8 @@ postgres:
   registry: "docker.io/centos"
   # false for running Postgres as a container and true for using External Postgres database
   isExternal: true
+  # false for maintaining your own ${release_name}-blackduck-db-creds secret to keep your database passwords out of values.yaml
+  createSecret: true
   # required only for external postgres, for postgres as a container, it will point to <name>-blackduck-postgres
   host:
   port: 5432


### PR DESCRIPTION
For those who deploy blackduck via helm, and maintain their helm charts and values.yaml files in source control, currently the database passwords are maintained in values.yaml.
For security best practices the postgres passwords should not be checked into source control.
This PR allows you to mark the creation of secrets as false - which will allow consumers to maintain their own `<RELEASE>-blackduck-db-creds` secrets using their own process and secrets management solution.
Ex.
```
postgres:
  createSecret: false
```