### PR TITLE
Execute the postres provisioning script during helm upgrades as well

### DIFF
--- a/kubernetes/blackduck/templates/postgres-init.yaml
+++ b/kubernetes/blackduck/templates/postgres-init.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "bd.labels" . | nindent 4 }}
     component: postgres
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation
   name: {{ .Release.Name }}-blackduck-postgres-init-config
@@ -23,7 +23,7 @@ metadata:
     {{- include "bd.labelsWithoutVersion" . | nindent 4 }}
     component: postgres-init
   annotations:
-    helm.sh/hook: post-install
+    helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
   name: {{ .Release.Name }}-blackduck-postgres-init


### PR DESCRIPTION
Is there any reason to not run the postgres script during helm updates?
This would help out if you run helm upgrade and expect it to e.g. update the blackduck_user password.
