### PR TITLE
add possibility to set initContainer resources

### DIFF
--- a/kubernetes/blackduck/README.md
+++ b/kubernetes/blackduck/README.md
@@ -280,6 +280,7 @@ The following table lists the configurable parameters of the Black Duck chart an
 | `init.imageTag` | Image tag to be override at container level | `1.0.0` |
 | `init.securityContext` | Init security context at container level | `1000` |
 | `init.postCommand` | Docker entrypoint post command | `e.g. In case of Istio, can be added as --set init.postCommand="curl -X POST http://localhost:15020/quitquitquit"` |
+| `init.resources` | init container resource requests & limits | `{}` |
 
 ### Authentication Pod Configuration
 

--- a/kubernetes/blackduck/templates/authentication.yaml
+++ b/kubernetes/blackduck/templates/authentication.yaml
@@ -118,6 +118,8 @@ spec:
         - "--postgres-user=$(POSTGRESQL_USER)" # Postgres database user
         - "--postgres-ssl-mode=$(POSTGRES_SSL_MODE)" # Postgres SSL mode
         imagePullPolicy: Always
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.init.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/templates/binary-scanner.yaml
+++ b/kubernetes/blackduck/templates/binary-scanner.yaml
@@ -71,6 +71,8 @@ spec:
         - "--postgres-user=$(POSTGRESQL_USER)" # Postgres database user
         - "--postgres-ssl-mode=$(POSTGRES_SSL_MODE)" # Postgres SSL mode
         imagePullPolicy: Always
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.init.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/templates/bomengine.yaml
+++ b/kubernetes/blackduck/templates/bomengine.yaml
@@ -93,6 +93,8 @@ spec:
         - "--postgres-user=$(POSTGRES_USER)" # Postgres database user
         - "--postgres-ssl-mode=$(POSTGRES_SSL_MODE)" # Postgres SSL mode
         imagePullPolicy: Always
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.init.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/templates/documentation.yaml
+++ b/kubernetes/blackduck/templates/documentation.yaml
@@ -93,6 +93,8 @@ spec:
         - "--postgres-user=$(POSTGRESQL_USER)" # Postgres database user
         - "--postgres-ssl-mode=$(POSTGRES_SSL_MODE)" # Postgres SSL mode
         imagePullPolicy: Always
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.init.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/templates/jobrunner.yaml
+++ b/kubernetes/blackduck/templates/jobrunner.yaml
@@ -94,6 +94,8 @@ spec:
         - "--postgres-user=$(POSTGRESQL_USER)" # Postgres database user
         - "--postgres-ssl-mode=$(POSTGRES_SSL_MODE)" # Postgres SSL mode
         imagePullPolicy: Always
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.init.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/templates/matchengine.yaml
+++ b/kubernetes/blackduck/templates/matchengine.yaml
@@ -94,6 +94,8 @@ spec:
         - "--postgres-user=$(POSTGRES_USER)" # Postgres database user
         - "--postgres-ssl-mode=$(POSTGRES_SSL_MODE)" # Postgres SSL mode
         imagePullPolicy: Always
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.init.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/templates/postgres-init.yaml
+++ b/kubernetes/blackduck/templates/postgres-init.yaml
@@ -95,6 +95,8 @@ spec:
         volumeMounts:
           - mountPath: /tmp/postgres-init
             name: postgres-init
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.postgres.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/templates/rabbitmq.yaml
+++ b/kubernetes/blackduck/templates/rabbitmq.yaml
@@ -114,6 +114,8 @@ spec:
         - "--postgres-user=$(POSTGRESQL_USER)" # Postgres database user
         - "--postgres-ssl-mode=$(POSTGRES_SSL_MODE)" # Postgres SSL mode
         imagePullPolicy: Always
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.init.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/templates/registration.yaml
+++ b/kubernetes/blackduck/templates/registration.yaml
@@ -118,6 +118,8 @@ spec:
         - "--postgres-user=$(POSTGRESQL_USER)" # Postgres database user
         - "--postgres-ssl-mode=$(POSTGRES_SSL_MODE)" # Postgres SSL mode
         imagePullPolicy: Always
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.init.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/templates/scan.yaml
+++ b/kubernetes/blackduck/templates/scan.yaml
@@ -93,6 +93,8 @@ spec:
         - "--postgres-user=$(POSTGRESQL_USER)" # Postgres database user
         - "--postgres-ssl-mode=$(POSTGRES_SSL_MODE)" # Postgres SSL mode
         imagePullPolicy: Always
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.init.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/templates/uploadcache.yaml
+++ b/kubernetes/blackduck/templates/uploadcache.yaml
@@ -119,6 +119,8 @@ spec:
         - "--postgres-user=$(POSTGRESQL_USER)" # Postgres database user
         - "--postgres-ssl-mode=$(POSTGRES_SSL_MODE)" # Postgres SSL mode
         imagePullPolicy: Always
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.init.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/templates/webapp-logstash.yaml
+++ b/kubernetes/blackduck/templates/webapp-logstash.yaml
@@ -162,6 +162,8 @@ spec:
         - "--postgres-user=$(POSTGRESQL_USER)" # Postgres database user
         - "--postgres-ssl-mode=$(POSTGRES_SSL_MODE)" # Postgres SSL mode
         imagePullPolicy: Always
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.init.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/templates/webserver.yaml
+++ b/kubernetes/blackduck/templates/webserver.yaml
@@ -139,6 +139,8 @@ spec:
         - "--postgres-user=$(POSTGRESQL_USER)" # Postgres database user
         - "--postgres-ssl-mode=$(POSTGRES_SSL_MODE)" # Postgres SSL mode
         imagePullPolicy: Always
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.init.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/templates/webui.yaml
+++ b/kubernetes/blackduck/templates/webui.yaml
@@ -57,6 +57,8 @@ spec:
         image: {{ .Values.registry }}/synopsys-init:{{ .Values.init.imageTag }}
         {{- end}}
         imagePullPolicy: Always
+        resources:
+          {{- toYaml .Values.init.resources | nindent 10 }}
         {{- with .Values.init.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}

--- a/kubernetes/blackduck/values.yaml
+++ b/kubernetes/blackduck/values.yaml
@@ -140,6 +140,7 @@ init:
   securityContext: {}
   # postgres container's post initialize docker entrypoint command
   postCommand:
+  resources: {}
 
 authentication:
   # override the docker registry at container level


### PR DESCRIPTION
This allows the blackduck helm chart to be deployed, even if the cluster requires committed resources on all components.