### PR TITLE
feat(blackduck): argoCD hooks

### DIFF
--- a/kubernetes/blackduck/templates/postgres-config.yaml
+++ b/kubernetes/blackduck/templates/postgres-config.yaml
@@ -19,6 +19,9 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade,post-upgrade
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation
+    argocd.argoproj.io/hook: PreSync,PostSync
+    argocd.argoproj.io/sync-wave: "-5"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
   name: {{ .Release.Name }}-blackduck-db-config
   namespace: {{ .Release.Namespace }}
 ---

--- a/kubernetes/blackduck/templates/postgres-init.yaml
+++ b/kubernetes/blackduck/templates/postgres-init.yaml
@@ -12,6 +12,9 @@ metadata:
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-5"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
   name: {{ .Release.Name }}-blackduck-postgres-init-config
   namespace: {{ .Release.Namespace }}
 {{ if eq .Values.status "Running" }}


### PR DESCRIPTION
ArgoCD uses Helm just as YAML generator.
Custom ArgoCD plugins ignore helm hooks as well.

More details:
https://argo-cd.readthedocs.io/en/stable/user-guide/helm/

Signed-off-by: abdennour