### PR TITLE
CLOPS-15061

### DIFF
--- a/kubernetes/blackduck/values.yaml
+++ b/kubernetes/blackduck/values.yaml
@@ -205,7 +205,7 @@ binaryscanner:
   resources:
     limits:
       cpu: "1000m"
-      memory: "2048Mi"
+      memory: "4096Mi"
 
 bomengine:
   # override the docker registry at container level


### PR DESCRIPTION
Increasing binary scan container from 2GB to 4GB of memory as requested in https://jira-sig.internal.synopsys.com/browse/CLOPS-15061