### PR TITLE
Add support for specifying the hostname when using OpenShift.

### DIFF
--- a/kubernetes/blackduck/README.md
+++ b/kubernetes/blackduck/README.md
@@ -128,7 +128,11 @@ You can access the Black Duck UI by https://${EXTERNAL_IP}
 
 ```bash
 $ export SERVICE_TYPE=OpenShift
-$ helm upgrade ${BD_NAME} synopsys/blackduck --namespace ${BD_NAME} --set exposedServiceType=${SERVICE_TYPE} --reuse-values
+$ export HOST_NAME=blackduck.example.com
+$ helm upgrade ${BD_NAME} synopsys/blackduck --namespace ${BD_NAME} \
+  --set exposedServiceType=${SERVICE_TYPE} \
+  --set route.hostname=${HOST_NAME} \
+  --reuse-values
 ```
 
 you can use the following command to get the OpenShift routes

--- a/kubernetes/blackduck/templates/webserver.yaml
+++ b/kubernetes/blackduck/templates/webserver.yaml
@@ -28,7 +28,7 @@ metadata:
   name: {{ .Release.Name }}-blackduck
   namespace: {{ .Release.Namespace }}
 spec:
-  host: ""
+  host: "{{ .Values.route.hostname }}"
   port:
     targetPort: port-443
   tls:

--- a/kubernetes/blackduck/values.yaml
+++ b/kubernetes/blackduck/values.yaml
@@ -27,6 +27,10 @@ exposedServiceType: NodePort
 # custom port to expose the NodePort service on
 exposedNodePort: ""
 
+# The hostname for the OpenShift route. An empty hostname lets OpenShift autogenerate the hostname.
+route:
+  hostname: ""
+
 # enable Persistent Storage for containers
 enablePersistentStorage: true
 # it will apply to all PVC's storage class but it can be override at container level


### PR DESCRIPTION
OpenShift users might not like to use the auto-genereated hostname for the Route. This PR added support for setting hostname via values file.