### PR TITLE
Reference correct Helm chart repository

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -8,8 +8,8 @@ Please note that this document applies *only* to Black Duck on Kubernetes/OpenSh
 
 A Helm chart is provided that describes a Kubernetes set of resources required to deploy Black Duck. You can find the charts within the blackduck folder on
 Kubernetes GitHub page. The Helm charts are also available in the public chart museum which can be pulled
-from https://repo.blackduck.com/artifactory/sig-cloudnative. Please use the following command to access the repository:
-`helm repo add blackduck https://repo.blackduck.com/artifactory/sig-cloudnative`
+from https://repo.blackduck.com/cloudnative. Please use the following command to access the repository:
+`helm repo add blackduck https://repo.blackduck.com/cloudnative`
 
 # Technical Resources
 

--- a/kubernetes/blackduck/README.md
+++ b/kubernetes/blackduck/README.md
@@ -12,7 +12,7 @@ This chart bootstraps **Black Duck** deployment on a **Kubernetes** cluster usin
 * Adding the Black Duck repository to your local Helm repository:
 
 ```bash
-$ helm repo add blackduck https://repo.blackduck.com/artifactory/sig-cloudnative
+$ helm repo add blackduck https://repo.blackduck.com/cloudnative
 ```
 
 ## Installing the Chart


### PR DESCRIPTION
Docs:
https://documentation.blackduck.com/bundle/bd-hub/page/Install_Kubernetes/InstallingBDHelm.html

The sig-cloudnative repository hasn't seen any new releases after 2024.10.0.